### PR TITLE
feat: Changed default probing method to TCP for prometheus-mktxp

### DIFF
--- a/charts/prometheus-mktxp/Chart.yaml
+++ b/charts/prometheus-mktxp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-mikrotik-exporter
 description: Prometheus Exporter for Mikrotik RouterOS devices.
 type: application
-version: 0.5.7
+version: 0.6.0
 # renovate: docker=ghcr.io/akpw/mktxp
 appVersion: 1.2.17
 home: https://github.com/akpw/mktxp

--- a/charts/prometheus-mktxp/templates/deployment.yaml
+++ b/charts/prometheus-mktxp/templates/deployment.yaml
@@ -81,21 +81,9 @@ spec:
               containerPort: 49090
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /
-              port: http-metrics
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: http-metrics
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/prometheus-mktxp/values.yaml
+++ b/charts/prometheus-mktxp/values.yaml
@@ -29,6 +29,22 @@ podSecurityContext: {}
 
 securityContext: {}
 
+livenessProbe:
+  tcpSocket:
+    port: http-metrics
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  tcpSocket:
+    port: http-metrics
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
 service:
   type: ClusterIP
   port: 49090


### PR DESCRIPTION
PR is changing the default probing methods (readiness, liveness) from `httpGet` to `tcpSocket` + the entire probing configuration has been moved to `values.yaml` allowing for full customization.

Closes #24 